### PR TITLE
Remove network_info output from vm_creation.tf

### DIFF
--- a/vm_creation.tf
+++ b/vm_creation.tf
@@ -10,8 +10,6 @@ data "tfe_outputs" "test" {
     workspace = "gcpnw"
 }
 
-output "network_info" {
-  value = data.tfe_outputs.test.id
 }
 
 


### PR DESCRIPTION
Remove output block for network_info.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **修正**
  * 不要なTerraform出力を削除しました。
  * 構成を簡潔化し、出力項目を整理しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->